### PR TITLE
add arn suffixes for direct use with CloudWatch

### DIFF
--- a/modules/lb/outputs.tf
+++ b/modules/lb/outputs.tf
@@ -6,6 +6,10 @@ output "server_lb_arn" {
   value = aws_lb.server.arn
 }
 
+output "server_lb_arn_suffix" {
+  value = aws_lb.server.arn_suffix
+}
+
 output "server_lb_name" {
   value = aws_lb.server.name
 }
@@ -16,6 +20,10 @@ output "mqtt_lb_dns" {
 
 output "mqtt_lb_arn" {
   value = var.mqtt_broker_type == "builtin" ? aws_lb.mqtt[0].arn : null
+}
+
+output "mqtt_lb_arn_suffix" {
+  value = var.mqtt_broker_type == "builtin" ? aws_lb.mqtt[0].arn_suffix : null
 }
 
 output "mqtt_lb_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "server_lb_arn" {
   description = "The ARN of the server load balancer"
 }
 
+output "server_lb_arn_suffix" {
+  value       = module.lb.server_lb_arn_suffix
+  description = "The ARN suffix of the server load balancer for use with CloudWatch"
+}
+
 output "server_lb_name" {
   value       = module.lb.server_lb_name
   description = "The name of the server load balancer"
@@ -21,6 +26,11 @@ output "mqtt_lb_dns_name" {
 output "mqtt_lb_arn" {
   value       = module.lb.mqtt_lb_arn
   description = "The ARN of the mqtt load balancer"
+}
+
+output "mqtt_lb_arn_suffix" {
+  value       = module.lb.mqtt_lb_arn_suffix
+  description = "The ARN suffix of the mqtt load balancer for use with CloudWatch"
 }
 
 output "mqtt_lb_name" {


### PR DESCRIPTION
add ARN suffixes for direct use with CloudWatch, also related to https://github.com/spacelift-io/terraform-aws-ecs-spacelift-selfhosted/pull/37